### PR TITLE
[TRI-179] alert managing test - url direct connect.

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -31,8 +31,9 @@ services:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=profect1234*
       - GF_USERS_ALLOW_SIGN_UP=false
-      - GF_SERVER_ROOT_URL=%(protocol)s://%(domain)s/monitoring
+      - GF_SERVER_ROOT_URL=https://catch-ping.com/monitoring
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
+      - GF_EXTERNAL_URL=https://catch-ping.com/monitoring
     networks:
       - monitoring
     depends_on:


### PR DESCRIPTION
# ☝️Issue Number

- #9 

# 🔎 Key Changes
- Grafana Webhook alert Settting

# 💌 To Reviewers
- Discord webhook 설정으로 Memory, RAM이 80%이상 차지하고 있을때 디스코드로 알람가게 설정했습니다.
- 자세한건 Notion Ticket을 확인해주세요!
https://www.notion.so/Cloud-Prometheus-Alertmanager-Discord-1acea615225080119da5c4b3005e9a1e?pvs=4