### PR TITLE
[TRI-211] RDB grafana metric setting & Connect.

### DIFF
--- a/monitoring/cloudwatch_exporter/config.yml
+++ b/monitoring/cloudwatch_exporter/config.yml
@@ -1,7 +1,5 @@
 region: ap-northeast-2  # 귀하의 AWS 리전에 맞게 변경하세요
 
-region: ap-northeast-2  # 귀하의 AWS 리전에 맞게 변경하세요
-
 metrics:
   - aws_namespace: AWS/RDS
     aws_metric_name: CPUUtilization

--- a/monitoring/cloudwatch_exporter/config.yml
+++ b/monitoring/cloudwatch_exporter/config.yml
@@ -1,0 +1,59 @@
+region: ap-northeast-2  # 귀하의 AWS 리전에 맞게 변경하세요
+
+region: ap-northeast-2  # 귀하의 AWS 리전에 맞게 변경하세요
+
+metrics:
+  - aws_namespace: AWS/RDS
+    aws_metric_name: CPUUtilization
+    aws_dimensions: [DBInstanceIdentifier]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/RDS
+    aws_metric_name: DatabaseConnections
+    aws_dimensions: [DBInstanceIdentifier]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/RDS
+    aws_metric_name: FreeableMemory
+    aws_dimensions: [DBInstanceIdentifier]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/RDS
+    aws_metric_name: FreeStorageSpace
+    aws_dimensions: [DBInstanceIdentifier]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/RDS
+    aws_metric_name: ReadIOPS
+    aws_dimensions: [DBInstanceIdentifier]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/RDS
+    aws_metric_name: WriteIOPS
+    aws_dimensions: [DBInstanceIdentifier]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/RDS
+    aws_metric_name: DiskQueueDepth
+    aws_dimensions: [DBInstanceIdentifier]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/RDS
+    aws_metric_name: NetworkReceiveThroughput
+    aws_dimensions: [DBInstanceIdentifier]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/RDS
+    aws_metric_name: NetworkTransmitThroughput
+    aws_dimensions: [DBInstanceIdentifier]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/RDS
+    aws_metric_name: ReadLatency
+    aws_dimensions: [DBInstanceIdentifier]
+    aws_statistics: [Average]
+
+  - aws_namespace: AWS/RDS
+    aws_metric_name: WriteLatency
+    aws_dimensions: [DBInstanceIdentifier]
+    aws_statistics: [Average]

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -57,6 +57,19 @@ services:
     networks:
       - monitoring
 
+  cloudwatch-exporter:
+    image: prom/cloudwatch-exporter
+    container_name: cloudwatch-exporter
+    restart: unless-stopped
+    volumes:
+      - ~/cloudwatch_exporter/config.yml:/config/config.yml
+    command:
+      - '/config/config.yml'
+    ports:
+      - "9106:9106"
+    networks:
+      - monitoring
+
 networks:
   monitoring:
     driver: bridge

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -41,3 +41,10 @@ scrape_configs:
       - targets: ['10.0.172.33:9100']
         labels:
           instance: 'ml-server'
+
+  - job_name: 'cloudwatch'
+    scrape_interval: 60s
+    static_configs:
+      - targets: ['cloudwatch-exporter:9106']
+        labels:
+          instance: 'rds-metrics'


### PR DESCRIPTION
# ☝️Issue Number

- #13 

# 🔎 Key Changes
- RDB Monitoring (Grafana Dashboard 설정 + Cloudwatch Metric 수집 기능 설정)
- DB Monitoring Page Link: https://catch-ping.com/monitoring/d/eeg3cf85afdhcb/trinity-db-instance?orgId=1&from=now-24h&to=now&timezone=browser

# 💌 To Reviewers
- 수집하고 있는 Metric List 입니다.

핵심 메트릭 패널 구성
- CPU 사용률 게이지 차트 (쿼리: `aws_rds_cpuutilization_average`)
- 데이터베이스 연결 수 싱글 스탯 (쿼리: `aws_rds_database_connections_average`)
- 사용 가능 메모리 게이지 차트 (쿼리: `aws_rds_freeable_memory_average`, 단위: MB)
- 사용 가능 스토리지 공간 게이지 차트 (쿼리: `aws_rds_free_storage_space_average`, 임계값 설정)
- 읽기/쓰기 IOPS 시계열 그래프 (쿼리: `aws_rds_read_iops_average`, `aws_rds_write_iops_average`)

부가 정보 패널 구성
- RDS 인스턴스 기본 정보: Uptime, CPU 코어 수, 메모리/스토리지 용량 등
- 추가 성능 지표: 네트워크 처리량, 디스크 대기열, 읽기/쓰기 지연 시간 등

- 자세한건 Notion Ticket LInk를 확인해주세요!
https://www.notion.so/Cloud-Monitoring-Grafana-add-to-RDS-DB-1b9ea615225080c1b7b2f6a69df589e0?pvs=4
